### PR TITLE
Forces all logs into a standard format and single destination

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,20 @@
 require 'mocktopus'
 
+class LoggerMiddleware
+
+  def initialize(app, logger)
+    @app, @logger = app, logger
+  end
+
+  def call(env)
+    env['rack.errors'] = @logger
+    @app.call(env)
+  end
+
+end
+
+use Rack::CommonLogger, $logger
+use LoggerMiddleware, $logger
+set :show_exceptions, false
+
 run Sinatra::Application

--- a/lib/mocktopus.rb
+++ b/lib/mocktopus.rb
@@ -1,5 +1,9 @@
 require 'logger'
-LOGGER = Logger.new('mocktopus.log', 'daily')
+
+$logger = Logger.new(STDOUT) unless $logger
+
+class ::Logger; alias_method :write, :info; end
+class ::Logger; alias_method :puts, :error; end
 
 require 'mocktopus/response'
 require 'mocktopus/input'

--- a/lib/mocktopus/input.rb
+++ b/lib/mocktopus/input.rb
@@ -49,7 +49,7 @@ module Mocktopus
 
       validate_instance_variables
 
-      LOGGER.debug("initialized input object from hash #{hash.inspect()}")
+      $logger.debug("initialized input object from hash #{hash.inspect()}")
     end
 
     def to_hash

--- a/lib/mocktopus/response.rb
+++ b/lib/mocktopus/response.rb
@@ -16,7 +16,7 @@ module Mocktopus
             :delay
 
     def initialize(hash)
-      LOGGER.debug("initializing response object")
+      $logger.debug("initializing response object")
       @code = hash['code']
       @headers = hash['headers']
       @body = hash['body']
@@ -30,7 +30,7 @@ module Mocktopus
 
       validate_instance_variables()
 
-      LOGGER.debug("initialized response object from hash #{hash.inspect()}")
+      $logger.debug("initialized response object from hash #{hash.inspect()}")
     end
 
   def to_hash

--- a/mocktopus.gemspec
+++ b/mocktopus.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '~> 0.14.0', '>= 0.14.0'
   s.add_development_dependency 'simplecov', '~> 0.9.2', '>= 0.9.2'
   s.add_development_dependency 'coveralls', '~> 0.7.11', '>= 0.7.11'
+  s.add_development_dependency 'pry', '~> 0.10.1', '>= 0.10.1'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,5 +29,7 @@ module Mocktopus
   class Test < Minitest::Test
     include Rack::Test::Methods
 
+      $logger = Logger.new('/dev/null')
+
   end
 end


### PR DESCRIPTION
I wanted to push all log messages into stdout, and let the user/consumer handle where to put logs, rather than the previous/default logging that puts Rack logs into stderr, other logs into stdout, then mocktopus logs in ./mocktopus.log.  This makes for a really confusing set of logs when running the mocktopus in init.d.  The hacks/monkey patches are my attempt to bring a stream of logs into one uniformly formatted stream of outputs.  In the future, we'll make it easier for consumers to configure or swap log destinations.  In my mind, this is better than what we had before.
