### PR TITLE
Make form data readable in call listing

### DIFF
--- a/lib/mocktopus/mock_api_call.rb
+++ b/lib/mocktopus/mock_api_call.rb
@@ -1,5 +1,6 @@
 require 'time'
 require 'json'
+require 'uri'
 
 module Mocktopus
 
@@ -17,7 +18,11 @@ module Mocktopus
       @verb = verb
       @headers = headers
       begin
-        @body = JSON.parse(body)
+        @body = if @headers.has_key?('content_type') && @headers['content_type'] == 'application/x-www-form-urlencoded'
+                  URI::decode_www_form_component(body).to_s
+                else
+                  JSON.parse(body)
+                end
       rescue
         @body = body
       end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class AppTest < Mocktopus::Test
-  
+
   def setup
 
   end
@@ -126,6 +126,7 @@ class AppTest < Mocktopus::Test
       "key1" => "value_one",
       "key2" => "value_two"
     }
+    header 'content-type', 'application/json'
     input = create_input(uri, verb, body, '', code, {}, '')
     post "/mocktopus/inputs/#{uri}", input
 

--- a/test/mock_api_call_test.rb
+++ b/test/mock_api_call_test.rb
@@ -32,4 +32,32 @@ class MockApiCallTest < Mocktopus::Test
     assert_equal 'String', s.class.name
   end
 
+  def test_constructor_form_data
+    path = ''
+    verb = 'POST'
+    headers = {}
+    headers['content_type'] = 'application/x-www-form-urlencoded'
+    expected_body = <<-EOH.sub(/\n$/, '')
+from=test.user@example.com&subject=Test Email&text=﻿TEST EMAIL&html=﻿<!DOCTYPE html>\r
+\r
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">\r
+<head>\r
+    <meta charset="utf-8" />\r
+    <title></title>\r
+</head>\r
+<body>\r
+    <p>\r
+        TEST EMAIL\r
+    </p>\r
+</body>\r
+</html>&to="TEST EMAIL" <response@example.com>&o:tag=test_template&o:testmode=yes
+EOH
+    body = "from%3Dtest.user%40example.com%26subject%3DTest+Email%26text%3D%EF%BB%BFTEST+EMAIL%26html%3D%EF%BB%BF%3C%21DOCTYPE+html%3E%0D%0A%0D%0A%3Chtml+lang%3D%22en%22+xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%3E%0D%0A%3Chead%3E%0D%0A++++%3Cmeta+charset%3D%22utf-8%22+%2F%3E%0D%0A++++%3Ctitle%3E%3C%2Ftitle%3E%0D%0A%3C%2Fhead%3E%0D%0A%3Cbody%3E%0D%0A++++%3Cp%3E%0D%0A++++++++TEST+EMAIL%0D%0A++++%3C%2Fp%3E%0D%0A%3C%2Fbody%3E%0D%0A%3C%2Fhtml%3E%26to%3D%22TEST+EMAIL%22+%3Cresponse%40example.com%3E%26o%3Atag%3Dtest_template%26o%3Atestmode%3Dyes"
+    call = Mocktopus::MockApiCall.new(path, verb, headers, body)
+    refute_nil call
+    assert_equal(path, call.path)
+    assert_equal(verb, call.verb)
+    assert_equal(headers, call.headers)
+    assert_equal(expected_body, call.body)
+  end
 end


### PR DESCRIPTION
Decodes form data into a more readable ASCII representation.
This doesn't affect matching mocks so you still have to prime
with the messier encoded form.