### PR TITLE
Add query parameter for mock_api_calls listing

### DIFF
--- a/lib/mocktopus/mock_api_call.rb
+++ b/lib/mocktopus/mock_api_call.rb
@@ -10,13 +10,15 @@ module Mocktopus
       :path,
       :verb,
       :headers,
-      :body
+      :body,
+      :matched
 
     def initialize(path, verb, headers, body)
       @timestamp = Time.now.utc.iso8601(10)
       @path = path
       @verb = verb
       @headers = headers
+      @matched = false
       begin
         @body = if @headers.has_key?('content_type') && @headers['content_type'] == 'application/x-www-form-urlencoded'
                   URI::decode_www_form_component(body).to_s
@@ -34,7 +36,8 @@ module Mocktopus
         'path' => @path,
         'verb' => @verb,
         'headers' => @headers,
-        'body' => @body
+        'body' => @body,
+        'matched' => @matched
       }
     end
 

--- a/lib/mocktopus/mock_api_call_container.rb
+++ b/lib/mocktopus/mock_api_call_container.rb
@@ -9,8 +9,16 @@ module Mocktopus
       @calls << mock_api_call
     end
 
-    def all
-      @calls.collect(&:to_hash)
+    def all(unmatched_only=false)
+      @calls.collect { |c|
+        if (unmatched_only && c.matched) then
+            nil
+        else
+          result = c.to_hash
+          result.delete('matched')
+          result
+        end
+      }.compact
     end
 
     def delete_all

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -127,8 +127,8 @@ class AppTest < Mocktopus::Test
       "key2" => "value_two"
     }
     header 'content-type', 'application/json'
-    input = create_input(uri, verb, body, '', code, {}, '')
-    post "/mocktopus/inputs/#{uri}", input
+    input = create_input(uri, verb, {}, body, code, {}, '')
+    post "/mocktopus/inputs/test_mock_api_calls", JSON.pretty_generate(input)
 
     post uri, JSON.pretty_generate(body)
     calls = get '/mocktopus/mock_api_calls'
@@ -257,6 +257,29 @@ class AppTest < Mocktopus::Test
     get random_uri
     assert_equal 428, last_response.status
     assert_equal random_uri, JSON.parse(last_response.body)['call']['path']
+  end
+
+  def test_mock_api_calls_unmatched
+    uri = '/test_unmatched_mock_api_calls/1'
+    verb = 'POST'
+    code = 200
+    body = {
+      "key1" => "value_one",
+      "key2" => "value_two"
+    }
+    input = create_input(uri, verb, {}, body, code, {}, '')
+    header 'content-type', 'application/json'
+    post "/mocktopus/inputs/test_unmatched_mock_api_calls", JSON.pretty_generate(input)
+
+    post uri, JSON.pretty_generate(body)
+    put uri, JSON.pretty_generate(body)
+    calls = get '/mocktopus/mock_api_calls?unmatched=true'
+    json = JSON.parse(calls.body)
+    this_test_call = json.select{|k| k['path'] == uri }.first
+    refute_nil this_test_call
+    assert_equal(uri, this_test_call['path'])
+    assert_equal("PUT", this_test_call['verb'])
+    assert_equal(body, this_test_call['body'])
   end
 
   private

--- a/test/mock_api_call_container_test.rb
+++ b/test/mock_api_call_container_test.rb
@@ -23,4 +23,16 @@ class MockApiCallContainerTest < Mocktopus::Test
     refute_nil all.select{|a| a['path'] == '/foo/bar/0'}.first
   end
 
+  def test_all_unmatched_only
+    container = Mocktopus::MockApiCallContainer.new
+    10.times do |i|
+      call = Mocktopus::MockApiCall.new("/foo/bar/#{i}", 'POST', {"header#{i}" => "header_#{i}"}, {"body#{i}" => "body_#{i}"})
+      container.add(call)
+      call.matched = (i % 2 == 0)
+    end
+    all = container.all(true)
+    assert_equal(5, all.length)
+    refute_nil all.select{|a| a['path'] == '/foo/bar/1'}.first
+  end
+
 end


### PR DESCRIPTION
When the query parameter is specified the mock_api_call listing is filtered to only show calls that didn't have a configured match. 